### PR TITLE
Fix check_module_exists() to use folder_paths

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -369,7 +369,7 @@ def override_class_with_distorch(cls):
 NODE_CLASS_MAPPINGS = {"DeviceSelectorMultiGPU": DeviceSelectorMultiGPU}
 
 def check_module_exists(module_path):
-    full_path = os.path.join("custom_nodes", module_path)
+    full_path = os.path.join(folder_paths.get_folder_paths("custom_nodes")[0], module_path)
     logging.info(f"MultiGPU: Checking for module at {full_path}")
 
     if not os.path.exists(full_path):


### PR DESCRIPTION
In Windows, module detection was failing because the method couldn't find the hard-coded custom_nodes/ folder in os.join.path.

Before:
```
MultiGPU: Checking for module at custom_nodes\x-flux-comfyui
MultiGPU: Module x-flux-comfyui not found - skipping
MultiGPU: Checking for module at custom_nodes\x-flux-comfyui
MultiGPU: Module x-flux-comfyui not found - skipping
MultiGPU: Checking for module at custom_nodes\ComfyUI-GGUF
MultiGPU: Module ComfyUI-GGUF not found - skipping
MultiGPU: Checking for module at custom_nodes\comfyui-gguf
MultiGPU: Module comfyui-gguf not found - skipping
MultiGPU: Registration complete. Final mappings: DeviceSelectorMultiGPU, UNETLoaderMultiGPU, VAELoaderMultiGPU, CLIPLoaderMultiGPU, DualCLIPLoaderMultiGPU, TripleCLIPLoaderMultiGPU, CheckpointLoaderSimpleMultiGPU, ControlNetLoaderMultiGPU
```

We switch to using folder_paths which will return a correct path regardless of the platform.

After:
```
MultiGPU: Checking for module at G:\ComfyUI_windows_portable\ComfyUI\custom_nodes\x-flux-comfyui
MultiGPU: Found x-flux-comfyui, creating compatible MultiGPU nodes
MultiGPU: Registered LoadFluxControlNetMultiGPU
MultiGPU: Checking for module at G:\ComfyUI_windows_portable\ComfyUI\custom_nodes\ComfyUI-GGUF
MultiGPU: Found ComfyUI-GGUF, creating compatible MultiGPU nodes
MultiGPU: Registered UnetLoaderGGUFMultiGPU
MultiGPU: Registered UnetLoaderGGUFDisTorchMultiGPU
MultiGPU: Registered UnetLoaderGGUFAdvancedMultiGPU
MultiGPU: Registered UnetLoaderGGUFAdvancedDisTorchMultiGPU
MultiGPU: Registered CLIPLoaderGGUFMultiGPU
MultiGPU: Registered CLIPLoaderGGUFDisTorchMultiGPU
MultiGPU: Registered DualCLIPLoaderGGUFMultiGPU
MultiGPU: Registered DualCLIPLoaderGGUFDisTorchMultiGPU
MultiGPU: Registered TripleCLIPLoaderGGUFMultiGPU
MultiGPU: Registered TripleCLIPLoaderGGUFDisTorchMultiGPU
MultiGPU: Registration complete. Final mappings: DeviceSelectorMultiGPU, UNETLoaderMultiGPU, VAELoaderMultiGPU, CLIPLoaderMultiGPU, DualCLIPLoaderMultiGPU, TripleCLIPLoaderMultiGPU, CheckpointLoaderSimpleMultiGPU, ControlNetLoaderMultiGPU, LoadFluxControlNetMultiGPU, UnetLoaderGGUFMultiGPU, UnetLoaderGGUFDisTorchMultiGPU, UnetLoaderGGUFAdvancedMultiGPU, UnetLoaderGGUFAdvancedDisTorchMultiGPU, CLIPLoaderGGUFMultiGPU, CLIPLoaderGGUFDisTorchMultiGPU, DualCLIPLoaderGGUFMultiGPU, DualCLIPLoaderGGUFDisTorchMultiGPU, TripleCLIPLoaderGGUFMultiGPU, TripleCLIPLoaderGGUFDisTorchMultiGPU

```