### PR TITLE
Add radial_sage_attention to wan loader

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -514,6 +514,8 @@ class WanVideoModelLoader:
                     "flash_attn_2",
                     "flash_attn_3",
                     "sageattn",
+                    "flex_attention",
+                    "radial_sage_attention"
                 ], {"default": "sdpa"}),
                 "compile_args": ("WANCOMPILEARGS", ),
                 "block_swap_args": ("BLOCKSWAPARGS", ),


### PR DESCRIPTION
https://github.com/mit-han-lab/radial-attention is the new hotness in wan video via https://github.com/kijai/ComfyUI-WanVideoWrapper/commit/8538c517e6b03961078fc7f20751a666116b0b87#diff-c0fcb5c89aef8e7aed675a4093586e115e883dd0bcf6aacc73eec3421fa25755R474

https://www.reddit.com/r/StableDiffusion/comments/1m3pock/holy_speed_balls_it_fast_after_some_config/

## Summary by Sourcery

Expose new attention types flex_attention and radial_sage_attention in the WAN loader node input options

New Features:
- Support flex_attention as an attention type in the WAN loader
- Support radial_sage_attention as an attention type in the WAN loader