### PR TITLE
Fix #104: Remove text_encoder_initial_device patch, simplify text encoder device handling, bump to 2.4.7

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -29,7 +29,6 @@ if not logger.handlers:
 # Global device state management
 current_device = mm.get_torch_device()
 current_text_encoder_device = mm.text_encoder_device()
-current_text_encoder_initial_device = mm.text_encoder_device()
 
 def set_current_device(device):
     global current_device
@@ -37,10 +36,9 @@ def set_current_device(device):
     logger.info(f"[MultiGPU Initialization] current_device set to: {device}")
 
 def set_current_text_encoder_device(device):
-    global current_text_encoder_device, current_text_encoder_initial_device
+    global current_text_encoder_device
     current_text_encoder_device = device
-    current_text_encoder_initial_device = device
-    logger.info(f"[MultiGPU Initialization] current_text_encoder_device and current_text_encoder_initial_device set to: {device}")
+    logger.info(f"[MultiGPU Initialization] current_text_encoder_device set to: {device}")
 
 def override_class(cls):
     class NodeOverride(cls):
@@ -137,19 +135,12 @@ def text_encoder_device_patched():
     logger.debug(f"[MultiGPU Core Patching] text_encoder_device_patched returning device: {device} (current_text_encoder_device={current_text_encoder_device})")
     return device
 
-def text_encoder_initial_device_patched(*args, **kwargs):
-    logger.debug(f"[MultiGPU Core Patching] text_encoder_initial_device_patched called with args={args}, kwargs={kwargs}")
-    # look at this later - I am not convinced that this isn't the better choice:
-    # return text_encoder_device_patched() 
-    return mm.text_encoder_device()
-
 
 logger.info(f"[MultiGPU Core Patching] Patching mm.get_torch_device, mm.text_encoder_device, and mm.text_encoder_initial_device")
 logger.debug(f"[MultiGPU DEBUG] Initial current_device: {current_device}")
 logger.debug(f"[MultiGPU DEBUG] Initial current_text_encoder_device: {current_text_encoder_device}")
 mm.get_torch_device = get_torch_device_patched
 mm.text_encoder_device = text_encoder_device_patched
-mm.text_encoder_initial_device = text_encoder_initial_device_patched
 
 def check_module_exists(module_path):
     full_path = os.path.join(folder_paths.get_folder_paths("custom_nodes")[0], module_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-multigpu"
 description = "Provides a suite of custom nodes to manage multiple GPUs for ComfyUI, including advanced model offloading for both GGUF and Safetensor formats with DisTorch, and bespoke MultiGPU support for WanVideoWrapper and other custom nodes."
-version = "2.4.6"
+version = "2.4.7"
 license = {file = "LICENSE"}
 
 [project.urls]


### PR DESCRIPTION
Background
The CLIP "compute" issue that previously motivated a local patch to mm.text_encoder_initial_device has been resolved upstream (commit edc8a4d). The custom patch is no longer necessary and maintaining it risks diverging from upstream behavior.

Summary of Changes
- __init__.py
  - Remove current_text_encoder_initial_device global and all references.
  - Remove text_encoder_initial_device_patched function.
  - Stop patching mm.text_encoder_initial_device; leave upstream behavior.
  - Simplify set_current_text_encoder_device (only updates current_text_encoder_device).
  - Adjust logging accordingly.
- pyproject.toml
  - Bump version from 2.4.6 to 2.4.7.

Rationale
- Upstream fix eliminates the need for the initial-device override.
- Reduces maintenance surface and potential for subtle device placement mismatches.
- Keeps the intended override for mm.text_encoder_device while avoiding redundant state.

Impact / Risk
- Behavior of mm.text_encoder_initial_device now mirrors upstream.
- No internal references were found depending on the removed state.

Testing Suggestions
- Run flows that exercise CLIP to ensure device placement is correct and no compute errors occur.
- Verify logs reflect expected device state during initialization and patching.
- Sanity-check GGUF/Safetensor model offloading across devices remains unaffected.

Diff / Commit Summary
- Commits ahead of main: 1 (`f7942dc`)
- Files changed: 2
  - __init__.py: remove initial-device patch and related state/logs.
  - pyproject.toml: version 2.4.6 -> 2.4.7.

Related
- Fixes #104

## Summary by Sourcery

Remove the custom patch for text_encoder_initial_device, streamline text encoder device state handling to rely on upstream behavior, and bump the package version to 2.4.7.

Enhancements:
- Eliminate the current_text_encoder_initial_device state and associated patching logic
- Simplify set_current_text_encoder_device to only manage the active encoder device and update logging
- Revert mm.text_encoder_initial_device to its upstream implementation

Build:
- Bump package version from 2.4.6 to 2.4.7