### PR TITLE
Update distorch_2.py: Fixed AttributeError: 'GGUFModelPatcher' object has no attribute 'model_patches_models' 

### DIFF
--- a/distorch_2.py
+++ b/distorch_2.py
@@ -83,8 +83,10 @@ def register_patched_safetensor_modelpatcher():
             models_temp = set()
             for m in models:
                 models_temp.add(m)
-                for mm_patch in m.model_patches_models():
-                    models_temp.add(mm_patch)
+                patches = m.model_patches_to(getattr(m, "load_device", "cuda"))
+                if patches:
+                    for mm_patch in patches:
+                        models_temp.add(mm_patch)
 
             models = models_temp
 


### PR DESCRIPTION
This pull request fixes the CLIPTextEncode error:
‘GGUFModelPatcher’ object has no attribute ‘model_patches_models’.

The issue occurred when using GGUF text encoders with MultiGPU enabled.
The patch adds compatibility handling to prevent this AttributeError.

Please review and accept this fix — it restores GGUF CLIPTextEncode functionality in ComfyUI with MultiGPU.
Screenshot of the error is attached below.

![model_patches_models](https://github.com/user-attachments/assets/bde483dd-6014-4463-8b98-6e61185d29ed)

## Summary by Sourcery

Bug Fixes:
- Prevent AttributeError in GGUFModelPatcher by using model_patches_to with getattr(m, 'load_device', 'cuda') instead of model_patches_models