### PR TITLE
Fix RMSNorm bias AttributeError and update block unpacking structure.

### DIFF
--- a/distorch_2.py
+++ b/distorch_2.py
@@ -377,9 +377,8 @@ def register_patched_safetensor_modelpatcher():
             # ============ Check embed_tokens weights AFTER all processing ============
             if embed_module is not None and hasattr(embed_module, 'weight'):
                 weight = embed_module.weight
-                _ = weight.float()
+                _ = weight.float().mean()
 
-            old_uuid = self.model.current_weight_patches_uuid
             self.model.current_weight_patches_uuid = self.patches_uuid
             self.model.device = device_to
 


### PR DESCRIPTION
This PR aims to fix two compatibility issues in safetensor memory management:

1. [Fix: AttributeError: 'RMSNorm' object has no attribute 'bias'.](https://github.com/pollockjj/ComfyUI-MultiGPU/issues/148#issuecomment-3636647809)
Add patched get_key_weight() to handle missing attributes 
This error happens when you go for those kind of configurations:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9583123b-538d-4b58-9313-a42b4331b4c9" />

2.  Incorporate fix from [PR#151](https://github.com/pollockjj/ComfyUI-MultiGPU/pull/151)

PS: It's still on WIP,  when the prompt is long the image gets broken, can't go further than that, some help will be appreciated.