### PR TITLE
[Bugfix?] Shallow copy inputs.

### DIFF
--- a/wrappers.py
+++ b/wrappers.py
@@ -22,11 +22,11 @@ def _create_distorch_safetensor_v2_override(cls, device_param_name, device_sette
     class NodeOverrideDisTorchSafetensorV2(cls):
         @classmethod
         def INPUT_TYPES(s):
-            inputs = copy.deepcopy(cls.INPUT_TYPES())
+            inputs = cls.INPUT_TYPES().copy()
             devices = get_device_list()
             default_device = devices[1] if len(devices) > 1 else devices[0]
 
-            inputs["optional"] = inputs.get("optional", {})
+            inputs["optional"] = inputs.get("optional", {}).copy()
             inputs["optional"][device_param_name] = (devices, {"default": default_device})
             inputs["optional"]["virtual_vram_gb"] = ("FLOAT", {"default": 4.0, "min": 0.0, "max": 128.0, "step": 0.1})
             inputs["optional"]["donor_device"] = (devices, {"default": "cpu"})
@@ -177,10 +177,10 @@ def override_class_with_distorch_gguf(cls):
     class NodeOverrideDisTorchGGUFLegacy(cls):
         @classmethod
         def INPUT_TYPES(s):
-            inputs = copy.deepcopy(cls.INPUT_TYPES())
+            inputs = cls.INPUT_TYPES().copy()
             devices = get_device_list()
             default_device = devices[1] if len(devices) > 1 else devices[0]
-            inputs["optional"] = inputs.get("optional", {})
+            inputs["optional"] = inputs.get("optional", {}).copy()
             inputs["optional"]["device"] = (devices, {"default": default_device})
             inputs["optional"]["virtual_vram_gb"] = ("FLOAT", {"default": 4.0, "min": 0.0, "max": 24.0, "step": 0.1})
             inputs["optional"]["use_other_vram"] = ("BOOLEAN", {"default": False})
@@ -245,11 +245,11 @@ def override_class_with_distorch_gguf_v2(cls):
     class NodeOverrideDisTorchGGUFv2(cls):
         @classmethod
         def INPUT_TYPES(s):
-            inputs = copy.deepcopy(cls.INPUT_TYPES())
+            inputs = cls.INPUT_TYPES().copy()
             devices = get_device_list()
             compute_device = devices[1] if len(devices) > 1 else devices[0]
 
-            inputs["optional"] = inputs.get("optional", {})
+            inputs["optional"] = inputs.get("optional", {}).copy()
             inputs["optional"]["compute_device"] = (devices, {"default": compute_device})
             inputs["optional"]["virtual_vram_gb"] = ("FLOAT", {"default": 4.0, "min": 0.0, "max": 128.0, "step": 0.1})
             inputs["optional"]["donor_device"] = (devices, {"default": "cpu"})
@@ -310,10 +310,10 @@ def override_class_with_distorch_clip(cls):
     class NodeOverrideDisTorchClip(cls):
         @classmethod
         def INPUT_TYPES(s):
-            inputs = copy.deepcopy(cls.INPUT_TYPES())
+            inputs = cls.INPUT_TYPES().copy()
             devices = get_device_list()
             default_device = devices[1] if len(devices) > 1 else devices[0]
-            inputs["optional"] = inputs.get("optional", {})
+            inputs["optional"] = inputs.get("optional", {}).copy()
             inputs["optional"]["device"] = (devices, {"default": default_device})
             inputs["optional"]["virtual_vram_gb"] = ("FLOAT", {"default": 4.0, "min": 0.0, "max": 24.0, "step": 0.1})
             inputs["optional"]["use_other_vram"] = ("BOOLEAN", {"default": False})
@@ -377,10 +377,10 @@ def override_class_with_distorch_clip_no_device(cls):
     class NodeOverrideDisTorchClipNoDevice(cls):
         @classmethod
         def INPUT_TYPES(s):
-            inputs = copy.deepcopy(cls.INPUT_TYPES())
+            inputs = cls.INPUT_TYPES().copy()
             devices = get_device_list()
             default_device = devices[1] if len(devices) > 1 else devices[0]
-            inputs["optional"] = inputs.get("optional", {})
+            inputs["optional"] = inputs.get("optional", {}).copy()
             inputs["optional"]["device"] = (devices, {"default": default_device})
             inputs["optional"]["virtual_vram_gb"] = ("FLOAT", {"default": 4.0, "min": 0.0, "max": 24.0, "step": 0.1})
             inputs["optional"]["use_other_vram"] = ("BOOLEAN", {"default": False})
@@ -451,10 +451,10 @@ def override_class(cls):
     class NodeOverride(cls):
         @classmethod
         def INPUT_TYPES(s):
-            inputs = copy.deepcopy(cls.INPUT_TYPES())
+            inputs = cls.INPUT_TYPES().copy()
             devices = get_device_list()
             default_device = devices[1] if len(devices) > 1 else devices[0]
-            inputs["optional"] = inputs.get("optional", {})
+            inputs["optional"] = inputs.get("optional", {}).copy()
             inputs["optional"]["device"] = (devices, {"default": default_device})
             return inputs
 
@@ -488,10 +488,10 @@ def override_class_offload(cls):
     class NodeOverride(cls):
         @classmethod
         def INPUT_TYPES(s):
-            inputs = copy.deepcopy(cls.INPUT_TYPES())
+            inputs = cls.INPUT_TYPES().copy()
             devices = get_device_list()
             default_device = devices[1] if len(devices) > 1 else devices[0]
-            inputs["optional"] = inputs.get("optional", {})
+            inputs["optional"] = inputs.get("optional", {}).copy()
             inputs["optional"]["device"] = (devices, {"default": default_device})
             inputs["optional"]["offload_device"] = (devices, {"default": "cpu"})
             return inputs
@@ -526,10 +526,10 @@ def override_class_clip(cls):
     class NodeOverride(cls):
         @classmethod
         def INPUT_TYPES(s):
-            inputs = copy.deepcopy(cls.INPUT_TYPES())
+            inputs = cls.INPUT_TYPES().copy()
             devices = get_device_list()
             default_device = devices[1] if len(devices) > 1 else devices[0]
-            inputs["optional"] = inputs.get("optional", {})
+            inputs["optional"] = inputs.get("optional", {}).copy()
             inputs["optional"]["device"] = (devices, {"default": default_device})
             return inputs
 
@@ -558,10 +558,10 @@ def override_class_clip_no_device(cls):
     class NodeOverride(cls):
         @classmethod
         def INPUT_TYPES(s):
-            inputs = copy.deepcopy(cls.INPUT_TYPES())
+            inputs = cls.INPUT_TYPES().copy()
             devices = get_device_list()
             default_device = devices[1] if len(devices) > 1 else devices[0]
-            inputs["optional"] = inputs.get("optional", {})
+            inputs["optional"] = inputs.get("optional", {}).copy()
             inputs["optional"]["device"] = (devices, {"default": default_device})
             return inputs
 


### PR DESCRIPTION
Hey, @pollockjj .
Currently, the node wrappers deep copy the inputs and edit them, adding more optional parameters.
I believe this is too aggressive. It breaks connectivity with folder_paths lists, which means the multigpu nodes' input folders can no longer be updated on the fly like regular unet / checkpoint etc (I wrote an extension which does that since models are on separate drives, not sure if comfy offers a similar functionality out of box).
Since it seems the only reason to create a copy in the first place is only to add more opt parms, rather than modify the existing ones in any way, a copy of the inputs + optional dicts is sufficient for the desired effect without breaking anything.