### PR TITLE
fix(florence2): delegate to upstream INPUT_TYPES + forward args by kwargs

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -192,80 +192,39 @@ class LTXVLoader:
 class Florence2ModelLoader:
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {
-            "model": ([item.name for item in Path(folder_paths.models_dir, "LLM").iterdir() if item.is_dir()], {"tooltip": "models are expected to be in Comfyui/models/LLM folder"}),
-            "precision": (['fp16','bf16','fp32'],),
-            "attention": (
-                    [ 'flash_attention_2', 'sdpa', 'eager'],
-                    {
-                    "default": 'sdpa'
-                    }),
-            },
-            "optional": {
-                "lora": ("PEFTLORA",),
-                "convert_to_safetensors": ("BOOLEAN", {"default": False, "tooltip": "Some of the older model weights are not saved in .safetensors format, which seem to cause longer loading times, this option converts the .bin weights to .safetensors"}),
-            }
-        }
+        # Delegate to upstream so the input set tracks Florence2 verbatim
+        # (e.g. post-rewrite removal of `attention` from required) and so
+        # upstream's `model_paths` class attribute gets populated as a
+        # side-effect — `loadmodel` reads it via `Florence2ModelLoader.model_paths.get(model)`.
+        return NODE_CLASS_MAPPINGS["Florence2ModelLoader"].INPUT_TYPES()
 
     RETURN_TYPES = ("FL2MODEL",)
     RETURN_NAMES = ("florence2_model",)
     FUNCTION = "loadmodel"
     CATEGORY = "Florence2"
 
-    def loadmodel(self, model, precision, attention, lora=None, convert_to_safetensors=False):
-        """Load Florence2 vision model with specified precision and attention mode."""
+    def loadmodel(self, *args, **kwargs):
+        """Forward to the upstream Florence2 loader without re-binding args."""
         original_loader = NODE_CLASS_MAPPINGS["Florence2ModelLoader"]()
-        return original_loader.loadmodel(model, precision, attention, lora, convert_to_safetensors)
+        return original_loader.loadmodel(*args, **kwargs)
 
 class DownloadAndLoadFlorence2Model:
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": {
-            "model": (
-                    [
-                    'microsoft/Florence-2-base',
-                    'microsoft/Florence-2-base-ft',
-                    'microsoft/Florence-2-large',
-                    'microsoft/Florence-2-large-ft',
-                    'HuggingFaceM4/Florence-2-DocVQA',
-                    'thwri/CogFlorence-2.1-Large',
-                    'thwri/CogFlorence-2.2-Large',
-                    'gokaygokay/Florence-2-SD3-Captioner',
-                    'gokaygokay/Florence-2-Flux-Large',
-                    'MiaoshouAI/Florence-2-base-PromptGen-v1.5',
-                    'MiaoshouAI/Florence-2-large-PromptGen-v1.5',
-                    'MiaoshouAI/Florence-2-base-PromptGen-v2.0',
-                    'MiaoshouAI/Florence-2-large-PromptGen-v2.0',
-                    'PJMixers-Images/Florence-2-base-Castollux-v0.5'
-                    ],
-                    {
-                    "default": 'microsoft/Florence-2-base'
-                    }),
-            "precision": ([ 'fp16','bf16','fp32'],
-                    {
-                    "default": 'fp16'
-                    }),
-            "attention": (
-                    [ 'flash_attention_2', 'sdpa', 'eager'],
-                    {
-                    "default": 'sdpa'
-                    }),
-            },
-            "optional": {
-                "lora": ("PEFTLORA",),
-                "convert_to_safetensors": ("BOOLEAN", {"default": False, "tooltip": "Some of the older model weights are not saved in .safetensors format, which seem to cause longer loading times, this option converts the .bin weights to .safetensors"}),
-            }
-        }
+        # Delegate to upstream so the model list and signature stay in sync
+        # with kijai/ComfyUI-Florence2 (e.g. PromptGen v2.0 and Castollux
+        # additions, attention parameter relocation).
+        return NODE_CLASS_MAPPINGS["DownloadAndLoadFlorence2Model"].INPUT_TYPES()
 
     RETURN_TYPES = ("FL2MODEL",)
     RETURN_NAMES = ("florence2_model",)
     FUNCTION = "loadmodel"
     CATEGORY = "Florence2"
 
-    def loadmodel(self, model, precision, attention, lora=None, convert_to_safetensors=False):
-        """Download and load Florence2 model from HuggingFace."""
+    def loadmodel(self, *args, **kwargs):
+        """Forward to the upstream HuggingFace downloader/loader."""
         original_loader = NODE_CLASS_MAPPINGS["DownloadAndLoadFlorence2Model"]()
-        return original_loader.loadmodel(model, precision, attention, lora, convert_to_safetensors)
+        return original_loader.loadmodel(*args, **kwargs)
 
 class CheckpointLoaderNF4:
     @classmethod


### PR DESCRIPTION
Closes #188.

## Root cause

The Florence2 shim in [`nodes.py:192-218`](https://github.com/pollockjj/ComfyUI-MultiGPU/blob/main/nodes.py#L192-L218) (and the analogous `DownloadAndLoadFlorence2Model` shim) hard-codes its own INPUT_TYPES (inline \`iterdir\`, fixed model list, \`attention\` as required) and forwards \`loadmodel\` via the legacy positional signature \`(model, precision, attention, lora, convert_to_safetensors)\`.

kijai/ComfyUI-Florence2's April 2026 rewrite ([commit 9acc6e9](https://github.com/kijai/ComfyUI-Florence2/commit/9acc6e9)) changed both:

- INPUT_TYPES now sets \`s.model_paths = create_path_dict(folder_paths.get_folder_paths(\"LLM\"), …)\` as a class attribute and only renders \`model\`/\`precision\` as required (\`attention\` moved to optional/keyword-only).
- \`loadmodel\` signature reordered to \`(self, model, precision, lora=None, convert_to_safetensors=False, attention=None, **kwargs)\`, and reads the path via \`Florence2ModelLoader.model_paths.get(model)\`.

Two failure modes result for \`Florence2ModelLoaderMultiGPU\`:

1. **\`AttributeError: type object 'Florence2ModelLoader' has no attribute 'model_paths'\`** (the reporter's exact error). When only the shim's INPUT_TYPES gets called for the MultiGPU variant, \`model_paths\` never gets populated on the upstream class, so upstream's \`loadmodel\` raises on the class-attribute lookup. The reporter confirmed standalone \`Florence2ModelLoader\` works (so upstream's INPUT_TYPES fires for *its* node) but the MultiGPU wrapper does not.
2. **Silent argument mis-binding** when \`model_paths\` *is* populated. The shim's positional forward sends \`attention\` into upstream's \`lora\` slot, \`lora\` into \`convert_to_safetensors\`, and \`convert_to_safetensors\` into \`attention\`. Whatever runs downstream gets the wrong values — no error, just wrong behavior.

## Fix

- INPUT_TYPES delegates to \`NODE_CLASS_MAPPINGS[\"Florence2ModelLoader\"].INPUT_TYPES()\` (and \`\"DownloadAndLoadFlorence2Model\"\`). The upstream classmethod runs with \`s = upstream_class\`, populating \`model_paths\` as a side-effect any time the MultiGPU node's inputs are rendered. The returned dict is what the MultiGPU wrapper presents, so the form fields stay in sync with upstream.
- \`loadmodel\` becomes \`def loadmodel(self, *args, **kwargs)\` and forwards verbatim. Future upstream signature changes flow through without a follow-up shim edit.

## Verification

Standalone harness (\`verify_florence2_shim.py\`) reproduces both failure modes against a stub mirroring upstream's post-rewrite shape, then confirms the fix:

\`\`\`
Scenario A: upstream INPUT_TYPES never called (model_paths missing)
  pre-fix  loadmodel raises the reporter's AttributeError ✓
  post-fix loadmodel succeeds, args correctly bound      ✓

Scenario B: upstream INPUT_TYPES did run; signature mismatch is the issue
  pre-fix  loadmodel silently mis-binds attention into lora ✓
  post-fix loadmodel binds attention to attention           ✓
\`\`\`

The pre-fix output reproduces the reporter's exact error verbatim:
\`type object 'StubFlorence2Loader' has no attribute 'model_paths'\`.

## Scope notes

- No public API changes. Both shim classes keep the same name, FUNCTION, RETURN_TYPES, RETURN_NAMES, CATEGORY.
- The \`override_class_offload\` wrapper at [`__init__.py:756-757`](https://github.com/pollockjj/ComfyUI-MultiGPU/blob/main/__init__.py#L756-L757) is unchanged — it still subclasses these shims and adds the device/offload_device fields.
- Bonus side-effect: the model dropdown now reflects upstream's model list verbatim (Castollux, all PromptGen variants, etc.) without further maintenance.

Credit @msmittn for the clean repro + screenshot showing the standalone-vs-MultiGPU comparison that pinpointed the wrapper as the divergence point.