### PR TITLE
fix: load the CUDA runtime on Windows, and never let the P2P probe be fatal

### DIFF
--- a/p2p_registry.py
+++ b/p2p_registry.py
@@ -5,7 +5,9 @@ repeated CUDA runtime API calls.
 """
 
 import ctypes
+import glob
 import logging
+import os
 import torch
 
 logger = logging.getLogger("MultiGPU")
@@ -13,11 +15,39 @@ logger = logging.getLogger("MultiGPU")
 _libcudart = None
 
 
+def _cudart_candidates():
+    """CUDA runtime library names to try, most-specific first.
+
+    On Windows the runtime is cudart64_<major>.dll, not libcudart.so. Prefer the
+    copy PyTorch ships in torch/lib so the version always matches the build in
+    use; then PATH-resolved names; then the POSIX sonames.
+    """
+    names = []
+    if os.name == "nt":
+        try:
+            libdir = os.path.join(os.path.dirname(torch.__file__), "lib")
+            names.extend(sorted(glob.glob(os.path.join(libdir, "cudart64_*.dll")), reverse=True))
+        except Exception:
+            pass
+        names.extend(["cudart64_13.dll", "cudart64_12.dll", "cudart64_110.dll", "cudart64_101.dll"])
+    names.extend(["libcudart.so", "libcudart.dylib"])
+    return names
+
+
 def _get_libcudart():
-    """Load libcudart.so once and cache the handle."""
+    """Load the CUDA runtime once and cache the handle."""
     global _libcudart
     if _libcudart is None:
-        _libcudart = ctypes.CDLL("libcudart.so")
+        last_err = None
+        for name in _cudart_candidates():
+            try:
+                _libcudart = ctypes.CDLL(name)
+                logger.debug(f"[MultiGPU P2P] loaded CUDA runtime: {name}")
+                break
+            except OSError as e:
+                last_err = e
+        if _libcudart is None:
+            raise OSError(f"could not load CUDA runtime (tried {_cudart_candidates()})") from last_err
     return _libcudart
 
 
@@ -34,17 +64,44 @@ class MultiGPUP2PRegistry:
 
     @staticmethod
     def _raw_can_access_peer(device_a: int, device_b: int) -> bool:
-        """Call cudaDeviceCanAccessPeer via ctypes. Returns True if P2P is available."""
-        lib = _get_libcudart()
-        can_access = ctypes.c_int(0)
-        result = lib.cudaDeviceCanAccessPeer(ctypes.byref(can_access), device_a, device_b)
-        if result != 0:
+        """Return True if P2P is available between the two devices.
+
+        Prefers torch.cuda.can_device_access_peer, which does exist in torch 2.x
+        (the previous comment referred to "can_access_peer", which is not the
+        API name -- so this always fell through to ctypes).
+
+        This is an OPTIMIZATION probe: a False answer only means transfers get
+        staged through host memory. Every failure mode therefore degrades to
+        False rather than propagating -- an unloadable CUDA runtime must never
+        abort a render.
+        """
+        fn = getattr(torch.cuda, "can_device_access_peer", None)
+        if fn is not None:
+            try:
+                return bool(fn(device_a, device_b))
+            except Exception as e:
+                logger.warning(
+                    f"[MultiGPU P2P] torch.cuda.can_device_access_peer({device_a}, {device_b}) "
+                    f"failed ({e}); falling back to the CUDA runtime"
+                )
+
+        try:
+            lib = _get_libcudart()
+            can_access = ctypes.c_int(0)
+            result = lib.cudaDeviceCanAccessPeer(ctypes.byref(can_access), device_a, device_b)
+            if result != 0:
+                logger.warning(
+                    f"[MultiGPU P2P] cudaDeviceCanAccessPeer({device_a}, {device_b}) "
+                    f"returned error code {result}, assuming no P2P"
+                )
+                return False
+            return bool(can_access.value)
+        except Exception as e:
             logger.warning(
-                f"[MultiGPU P2P] cudaDeviceCanAccessPeer({device_a}, {device_b}) "
-                f"returned error code {result}, assuming no P2P"
+                f"[MultiGPU P2P] could not probe P2P for ({device_a}, {device_b}): {e}. "
+                f"Assuming no P2P; transfers will be staged through host memory."
             )
             return False
-        return bool(can_access.value)
 
     def can_access_peer(self, src_device: int, dst_device: int) -> bool:
         """Check if src_device can access dst_device memory via P2P.


### PR DESCRIPTION
First off — thank you for this pack. MultiGPU has been part of my ComfyUI setup for a long time, and DisTorch in particular solved problems nothing else was addressing. I know keeping up with ComfyUI's pace right now is brutal, especially with dynamic VRAM and comfy-kitchen moving under everyone's feet. I appreciate what you're doing here and I'm glad to help however is useful.

I hit a Windows bug this week and have a fix, plus some observations you may or may not want.

## The bug

`p2p_registry.py` hardcodes `ctypes.CDLL("libcudart.so")`, which cannot resolve on Windows — the runtime there is `cudart64_<major>.dll`. Any workflow that puts tensors on two different CUDA devices dies with:

```
FileNotFoundError: Could not find module 'libcudart.so' (or one of its dependencies).
```

Traceback ended at:

```
comfy_kitchen/backends/cuda/__init__.py:658   dequantize_nvfp4 -> _wrap_for_dlpack(qx)
custom_nodes/comfyui-multigpu/__init__.py:557   wrap_for_dlpack_with_device_guard
custom_nodes/comfyui-multigpu/p2p_registry.py:62/38/20
ctypes.CDLL("libcudart.so")
```

### Why it has stayed hidden

`__init__.py:557` reads:

```python
if tensor_device.index != exec_device.index and not p2p_registry.can_access_peer(...):
```

Python short-circuits `and`, so `can_access_peer()` is only evaluated when the indices differ. With one visible GPU they always match, so the call is never reached. It only fires once a user exposes a second GPU — which I'd guess is why it hasn't been reported. As far as I can tell this path has never executed on Windows.

## The fix (this PR)

1. Resolve the CUDA runtime per-platform — prefer the copy PyTorch ships in `torch/lib` so the version always matches the build in use, then PATH-resolved `cudart64_*.dll`, then the POSIX sonames.
2. Prefer `torch.cuda.can_device_access_peer`, and make the probe non-fatal. The comment above `MultiGPUP2PRegistry` refers to `torch.cuda.can_access_peer`, but the actual API name is `can_device_access_peer` and it does exist in torch 2.x — so the ctypes path was always being taken unnecessarily. And since this is only an optimization probe (False just means host staging), every failure mode now degrades to False rather than propagating. An unloadable CUDA runtime shouldn't be able to abort a render.

Verified on Windows 11, torch 2.13.0+cu130, ComfyUI 0.33.1, RTX 5070 Ti + RTX 3090: loads `torch/lib/cudart64_13.dll`, and `can_device_access_peer` returns False for all six ordered pairs without raising.

## Observations beyond the fix — offered as data, not as claims

Fixing the probe let execution get further, and then I hit things I could not fully characterize. Sharing in case it's useful; I may well be holding it wrong.

**1. With a GPU donor, a quantized model crashed the CUDA context.**

`UNETLoaderDisTorch2MultiGPU`, `compute_device=cuda:0` (5070 Ti 16GB), `donor_device=cuda:1` (3090 24GB), `virtual_vram_gb=12`, model = MiniMax H3 19.53GB (`Minimax H3 INT8/INT4 ConvRot`, comfy-kitchen native ops `asym_w4a8_int8, float8_e5m2, float8_e4m3fn, nvfp4, mxfp8, int8_tensorwise, convrot_w4a4`):

```
torch.AcceleratorError: CUDA error: an illegal memory access was encountered
  at comfy/model_management.py:1427 reset_cast_buffers -> torch.cuda.synchronize
Prompt executed in 6.85 seconds
```

Died during load, before sampling, and poisoned the context (server needed a restart). I did **not** run this under `CUDA_LAUNCH_BLOCKING=1`, so I don't know the real faulting kernel — the reported location is just where it surfaced. My guess is that comfy-kitchen's quantized kernels assume weights share one device, but that is a guess I haven't verified.

**2. With a stock bf16 model, the donor appeared not to engage at all.**

Same node, `donor_device=cuda:1`, Flux2 Klein 9B bf16 (16.91GB) on the same 16GB compute device. Allocation string parsed correctly:

```
DisTorch V2] Full allocation string: #cuda:0;8.0;cuda:1
```

It ran fine (8/8 steps, 66s) — but the donor GPU stayed at **451 MiB for the entire run** while the compute device carried the model at 15.3GB. I retried with `virtual_vram_gb=14.0`, which should have forced most of a 16.91GB model onto the donor, and the donor still never allocated anything (run finished in 12.7s, donor flat at 451 MiB). No `CPU-staging tensor from cuda:X to cuda:Y` messages appeared either.

So I don't have a single run where donation to a GPU demonstrably happened. I can't tell whether that's expected behaviour (dynamic VRAM absorbing it before DisTorch needs to donate), a config mistake on my end, or the donor path not engaging. **This is the part I'd most value your read on.**

For reference, P2P is unavailable here in both directions — `can_device_access_peer` is False for all pairs (consumer GeForce, no NVLink, and cross-generation Ampere/Blackwell). A bulk cross-GPU `copy_()` still measures **9.83 GB/s** CPU-staged, so the bandwidth is there even without P2P — which is why GPU-as-donor is appealing for those of us who are RAM-constrained.

## Context for why I was poking at this

I was chasing a slowdown and ended up benchmarking storage placement. Moving 42GB of models from a SATA SSD to NVMe took the same workflow from 29.19 s/it to 16.31 s/it (-44%), because 14.2GB/step was being streamed and the drive was saturated at 467 MB/s. The reason I wanted GPU-as-donor is that RAM caching is impossible on this box — the model set is ~34GB against 32GB installed — so a second GPU's VRAM was the only tier left above NVMe. More RAM is the real answer and I'm buying it, but the donor idea seemed worth testing.

Happy to run any diagnostic you'd like on this hardware (5070 Ti + 3090 + 5060 Ti, Windows 11, torch 2.13/cu130, ComfyUI 0.33.1), including the `CUDA_LAUNCH_BLOCKING=1` repro if that would help. And no rush on any of it — take the fix and ignore the rest if that's the useful part.
